### PR TITLE
Feature/175 add answer serializer and service layer

### DIFF
--- a/apps/qna/serializers/answer/answers.py
+++ b/apps/qna/serializers/answer/answers.py
@@ -1,0 +1,80 @@
+from typing import Any, Dict, List, cast
+
+from rest_framework import serializers
+
+from apps.qna.models.answer.answers import Answer
+from apps.qna.serializers.answer.author import AnswerAuthorSerializer
+from apps.qna.serializers.answer.comments import AnswerCommentSerializer
+
+
+class AnswerSerializer(serializers.ModelSerializer[Answer]):
+    author = AnswerAuthorSerializer(read_only=True)
+
+    preview_comments = serializers.SerializerMethodField()
+    total_comments_count = serializers.IntegerField(
+        source="comments.count",
+        read_only=True,
+    )
+
+    class Meta:
+        model = Answer
+        fields = [
+            "id",
+            "author",
+            "content",
+            "is_adopted",
+            "created_at",
+            "preview_comments",
+            "total_comments_count",
+        ]
+        read_only_fields = ["is_adopted", "created_at"]
+
+    def get_preview_comments(self, obj: Answer) -> List[Dict[str, Any]]:
+        comments = obj.comments.all()[:3]
+        data = AnswerCommentSerializer(comments, many=True).data
+        return cast(List[Dict[str, Any]], data)
+
+
+class AnswerInputSerializer(serializers.ModelSerializer[Answer]):
+    image_urls = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        write_only=True,
+        help_text="본문에 포함된 이미지 URL 리스트",
+    )
+
+    class Meta:
+        model = Answer
+        fields = ["content", "image_urls"]
+
+
+class AnswerAdoptRequestSerializer(serializers.Serializer[Any]):
+    question_id = serializers.IntegerField()
+    answer_id = serializers.IntegerField()
+    is_adopted = serializers.BooleanField()
+
+
+class AnswerCreateResponseSerializer(serializers.Serializer[Any]):
+    answer_id = serializers.IntegerField(source="id")
+    question_id = serializers.IntegerField(source="question.id")
+    author_id = serializers.IntegerField(source="author.id")
+    created_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
+
+
+class AnswerUpdateResponseSerializer(serializers.Serializer[Any]):
+    answer_id = serializers.IntegerField(source="id")
+    updated_at = serializers.DateTimeField(
+        source="modified_at",
+        format="%Y-%m-%d %H:%M:%S",
+    )
+
+
+class AnswerAdoptResponseSerializer(serializers.Serializer[Any]):
+    question_id = serializers.IntegerField(source="question.id")
+    answer_id = serializers.IntegerField(source="id")
+    is_adopted = serializers.BooleanField()
+
+
+class AdminAnswerDeleteResponseSerializer(serializers.Serializer[Any]):
+    answer_id = serializers.IntegerField()
+    deleted_comment_count = serializers.IntegerField()

--- a/apps/qna/serializers/answer/author.py
+++ b/apps/qna/serializers/answer/author.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+from django.contrib.auth import get_user_model
+from rest_framework import serializers
+
+User = get_user_model()
+
+
+class AnswerAuthorSerializer(serializers.ModelSerializer[Any]):
+    class Meta:
+        model = User
+        fields = ["id", "nickname", "profile_image_url", "role"]
+        read_only_fields = fields

--- a/apps/qna/serializers/answer/comments.py
+++ b/apps/qna/serializers/answer/comments.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+from rest_framework import serializers
+
+from apps.qna.models.answer.comments import AnswerComment
+from apps.qna.serializers.answer.author import AnswerAuthorSerializer
+
+
+class AnswerCommentSerializer(serializers.ModelSerializer[AnswerComment]):
+    author = AnswerAuthorSerializer(read_only=True)
+
+    class Meta:
+        model = AnswerComment
+        fields = ["id", "author", "content", "created_at"]
+        read_only_fields = ["created_at"]
+
+
+class CommentCreateResponseSerializer(serializers.Serializer[Any]):
+    comment_id = serializers.IntegerField(source="id")
+    answer_id = serializers.IntegerField(source="answer.id")
+    author_id = serializers.IntegerField(source="author.id")
+    created_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")

--- a/apps/qna/serializers/answer/images.py
+++ b/apps/qna/serializers/answer/images.py
@@ -1,0 +1,25 @@
+from typing import Any
+
+from rest_framework import serializers
+
+
+class AnswerImagePresignedURLSerializer(serializers.Serializer[Any]):
+    file_name = serializers.CharField(
+        help_text="업로드할 파일명 (확장자 포함, 예: image.jpg)",
+        required=True,
+        max_length=255,
+    )
+
+    def validate_file_name(self, value: str) -> str:
+        valid_image_extensions = {"png", "jpg", "jpeg", "gif", "webp"}
+
+        if "." not in value:
+            raise serializers.ValidationError("확장자가 포함된 파일명을 입력해주세요.")
+
+        ext = value.split(".")[-1].lower()
+
+        if ext not in valid_image_extensions:
+            allowed_exts = ", ".join(sorted(valid_image_extensions))
+            raise serializers.ValidationError(f"지원하지 않는 파일 형식입니다. ({allowed_exts}만 가능)")
+
+        return value

--- a/apps/qna/services/answer/service.py
+++ b/apps/qna/services/answer/service.py
@@ -1,0 +1,185 @@
+import re
+from typing import TYPE_CHECKING, Any, Dict, List, Set, cast
+
+from django.db import transaction
+from django.shortcuts import get_object_or_404
+from rest_framework.exceptions import ValidationError
+
+from apps.core.exceptions.exception_messages import EMS
+from apps.qna.models.answer.answers import Answer
+from apps.qna.models.answer.comments import AnswerComment
+from apps.qna.models.answer.images import AnswerImage
+from apps.qna.models.question import Question
+
+if TYPE_CHECKING:
+    from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
+
+    UserType = AbstractBaseUser | AnonymousUser
+    RealUser = Any
+else:
+    UserType = Any
+    RealUser = Any
+
+
+class AnswerService:
+    """
+    Answer 도메인의 비즈니스 로직 담당
+    """
+
+    ALLOWED_IMAGE_EXTENSIONS = {"png", "jpg", "jpeg", "gif", "webp"}
+
+    @staticmethod
+    def create_answer(user: UserType, question_id: int, content: str) -> Answer:
+        question = get_object_or_404(Question, pk=question_id)
+        real_user = cast(RealUser, user)
+
+        with transaction.atomic():
+            answer: Answer = Answer.objects.create(
+                author=real_user,
+                question=question,
+                content=content,
+            )
+            AnswerService._process_images_for_create(answer, content)
+            return answer
+
+    @staticmethod
+    def update_answer(user: UserType, answer: Answer, content: str) -> Answer:
+        if answer.author != user:
+            raise ValidationError(EMS.E403_OWNER_ONLY_EDIT("답변"))
+
+        with transaction.atomic():
+            answer.content = content
+            answer.save()
+            AnswerService._sync_images_for_update(answer, content)
+            return answer
+
+    @staticmethod
+    def delete_answer(user: UserType, answer: Answer) -> None:
+        if answer.author != user:
+            raise ValidationError(EMS.E403_PERMISSION_DENIED("삭제"))
+        answer.delete()
+
+    @staticmethod
+    def delete_answer_by_admin(user: UserType, answer_id: int) -> Dict[str, int]:
+        answer = get_object_or_404(Answer, pk=answer_id)
+        comment_count: int = answer.comments.count()
+        deleted_id: int = answer.id
+
+        answer.delete()
+
+        return {
+            "answer_id": deleted_id,
+            "deleted_comment_count": comment_count,
+        }
+
+    @staticmethod
+    def toggle_adoption(user: UserType, answer_id: int) -> Answer:
+        answer = get_object_or_404(Answer, pk=answer_id)
+        question: Question = answer.question
+
+        if question.author != user:
+            raise ValidationError(EMS.E403_QNA_PERMISSION_DENIED("답변 채택"))
+
+        if answer.author == user:
+            raise ValidationError(EMS.E403_ADOPT_OWNER_ONLY)
+
+        with transaction.atomic():
+            if answer.is_adopted:
+                answer.is_adopted = False
+            else:
+                if question.answers.filter(is_adopted=True).exists():
+                    raise ValidationError(EMS.E409_ALREADY_ADOPTED)
+                answer.is_adopted = True
+
+            answer.save()
+            return answer
+
+    @staticmethod
+    def _extract_image_keys(content: str) -> Set[str]:
+        if not content:
+            return set()
+
+        raw_keys: List[str] = re.findall(
+            r'answer_images/[^\s"\')>]+',
+            content,
+        )
+        clean_keys: Set[str] = set()
+
+        for key in raw_keys:
+            key = key.split("?", 1)[0]
+
+            if "." in key:
+                ext = key.rsplit(".", 1)[-1].lower()
+                if ext in AnswerService.ALLOWED_IMAGE_EXTENSIONS:
+                    clean_keys.add(key)
+
+        return clean_keys
+
+    @staticmethod
+    def _process_images_for_create(answer: Answer, content: str) -> None:
+        current_keys = AnswerService._extract_image_keys(content)
+
+        if current_keys:
+            images = [AnswerImage(answer=answer, image_url=key) for key in current_keys]
+            AnswerImage.objects.bulk_create(images)
+
+    @staticmethod
+    def _sync_images_for_update(answer: Answer, content: str) -> None:
+        current_keys = AnswerService._extract_image_keys(content)
+
+        db_keys_qs = AnswerImage.objects.filter(
+            answer=answer,
+        ).values_list("image_url", flat=True)
+        db_keys: Set[str] = set(db_keys_qs)
+
+        keys_to_delete = db_keys - current_keys
+        keys_to_create = current_keys - db_keys
+
+        if keys_to_delete:
+            AnswerImage.objects.filter(
+                answer=answer,
+                image_url__in=keys_to_delete,
+            ).delete()
+
+        if keys_to_create:
+            images = [AnswerImage(answer=answer, image_url=key) for key in keys_to_create]
+            AnswerImage.objects.bulk_create(images)
+
+
+class CommentService:
+    @staticmethod
+    def create_comment(
+        user: UserType,
+        answer_id: int,
+        content: str,
+    ) -> AnswerComment:
+        answer = get_object_or_404(Answer, pk=answer_id)
+        real_user = cast(RealUser, user)
+
+        return AnswerComment.objects.create(
+            author=real_user,
+            answer=answer,
+            content=content,
+        )
+
+    @staticmethod
+    def update_comment(
+        user: UserType,
+        comment: AnswerComment,
+        content: str,
+    ) -> AnswerComment:
+        if comment.author != user:
+            raise ValidationError(EMS.E403_OWNER_ONLY_EDIT("댓글"))
+
+        comment.content = content
+        comment.save()
+        return comment
+
+    @staticmethod
+    def delete_comment(
+        user: UserType,
+        comment: AnswerComment,
+    ) -> None:
+        if comment.author != user:
+            raise ValidationError(EMS.E403_PERMISSION_DENIED("삭제"))
+        comment.delete()


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #175 
- 작업 요약: serializer와 service 역할을 분리하여 책임을 명확히 분리했습니다.

## 📄 상세 내용
- Answer 관련 serializer 작성 (조회 / 입력 / 응답 분리)
- AnswerService 작성
  - Answer 생성, 수정, 삭제
  - service레벨에서는 answer단위의 이미지 동기화(GC) 로직사용
  - 채택/취소 비즈니스 로직
- View → Serializer → Service 호출 구조로 책임 흐름 정리
- mypy strict 환경을 고려한 타입 힌트 적용
  - ModelSerializer[T], Serializer[Any] 명시
  - TYPE_CHECKING 블록을 활용한 User 타입 처리
  - 필요 지점에 cast 사용
## 📸 스크린샷 (선택)

## 📝 기타 참고 사항


## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
