### PR TITLE
Refactor/288 admin question serializer list conversion

### DIFF
--- a/apps/exams/models/__init__.py
+++ b/apps/exams/models/__init__.py
@@ -1,6 +1,6 @@
 from apps.exams.models.exam import Exam
 from apps.exams.models.exam_deployment import DeploymentStatus, ExamDeployment
-from apps.exams.models.exam_question import ExamQuestion
+from apps.exams.models.exam_question import ExamQuestion, QuestionType
 from apps.exams.models.exam_submission import ExamSubmission
 
 __all__ = [
@@ -9,4 +9,5 @@ __all__ = [
     "ExamQuestion",
     "ExamSubmission",
     "DeploymentStatus",
+    "QuestionType",
 ]

--- a/apps/exams/tests/admin/test_question_crud.py
+++ b/apps/exams/tests/admin/test_question_crud.py
@@ -80,8 +80,16 @@ class ExamAdminQuestionViewTest(APITestCase):
                 "point": 1,
                 "explanation": "해설",
             }
+
+            # fill_blank 유형일 경우 필수 필드인 blank_count 추가
+            if q_type == "fill_blank":
+                data["blank_count"] = 1
+
             response = self.client.post(self.create_url, data, format="json")
-            self.assertEqual(response.status_code, status.HTTP_201_CREATED, f"Failed on type: {q_type}")
+
+            self.assertEqual(
+                response.status_code, status.HTTP_201_CREATED, f"Failed on type: {q_type}, Error: {response.data}"
+            )
 
     def test_create_question_explanation_empty_success(self) -> None:
         """explanation이 null로 들어와도 저장되는지 확인"""


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #288 
- 작업 요약: AdminExamQuestionSerializer 내 options 및 correct_answer 필드가 항상 리스트 형태의 JSON으로 저장되도록 전처리 로직을 추가했습니다.

## 📄 상세 내용
- [x] 데이터 일관성 보장: 클라이언트에서 단일 값(문자열, 숫자, 불리언)이나 집합(Set), 튜플(Tuple) 형태의 데이터를 보내더라도 DB에는 일관되게 [...] 형태의 리스트로 저장되도록 로직을 구현했습니다.
- [x] 공통 헬퍼 메서드 도입: options와 correct_answer에 동일하게 적용되는 리스트 변환 로직을 _to_list 메서드로 분리하여 코드 중복을 예방했습니다.

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
* 입력값이 None일 경우 빈 리스트([])를 반환하며, 0이나 False 같은 값은 리스트에 포함된 형태([0], [False])로 변환됩니다.

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
