### PR TITLE
Fix logic for course application eligibility

### DIFF
--- a/apps/courses/views.py
+++ b/apps/courses/views.py
@@ -70,8 +70,8 @@ class AvailableCoursesAPIView(APIView):
         responses={200: None},
     )
     def get(self, request: Request) -> Response:
-        cohorts = Cohort.objects.filter(
-            status=CohortStatusChoices.PENDING, start_date__gte=timezone.localdate()
-        ).select_related("course")
+        cohorts = Cohort.objects.select_related("course").exclude(
+            status=CohortStatusChoices.PENDING, start_date__gt=timezone.localdate()
+        )
         serializer = AvailableCourseSerializer(cohorts, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/apps/user/serializers/enrollment.py
+++ b/apps/user/serializers/enrollment.py
@@ -45,7 +45,6 @@ class EnrollStudentSerializer(serializers.Serializer[Any]):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         cohort_field = cast(serializers.PrimaryKeyRelatedField[Cohort], self.fields["cohort_id"])
-        cohort_field.queryset = Cohort.objects.filter(
-            status=CohortStatusChoices.PENDING,
-            start_date__gte=timezone.localdate(),
-        ).select_related("course")
+        cohort_field.queryset = Cohort.objects.select_related("course").exclude(
+            status=CohortStatusChoices.PENDING, start_date__gt=timezone.localdate()
+        )

--- a/apps/user/tests/test_enrollment_api.py
+++ b/apps/user/tests/test_enrollment_api.py
@@ -39,7 +39,7 @@ class EnrollmentAPIViewTests(TestCase):
             max_student=10,
             start_date=base_date + timedelta(days=3),
             end_date=base_date + timedelta(days=30),
-            status=CohortStatusChoices.PENDING,
+            status=CohortStatusChoices.IN_PROGRESS,
         )
 
     def test_enroll_student_creates_request(self) -> None:
@@ -70,13 +70,14 @@ class EnrollmentAPIViewTests(TestCase):
 
     def test_available_courses_returns_only_available(self) -> None:
         base_date = timezone.localdate()
+        # 대기중인 기수는 신청 불가
         Cohort.objects.create(
             course=self.course,
             number=2,
             max_student=10,
-            start_date=base_date - timedelta(days=10),
-            end_date=base_date - timedelta(days=1),
-            status=CohortStatusChoices.COMPLETED,
+            start_date=base_date + timedelta(days=1),
+            end_date=base_date + timedelta(days=10),
+            status=CohortStatusChoices.PENDING,
         )
         request = self.factory.get("/api/v1/courses/available")
         force_authenticate(request, user=self.user)


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 수강생 등록 시 이용 가능한 과정-기수 로직을 수정했습니다.

## 📄 상세 내용
- [x] 기수 상태가 Pending이고, 시작일자가 아직 도래하지 않은 경우 신청 불가로 처리하도록 로직 수정.

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).