### PR TITLE
Add default value for `purpose` field in EmailRequestSerializer

### DIFF
--- a/apps/user/serializers/verification.py
+++ b/apps/user/serializers/verification.py
@@ -15,7 +15,7 @@ class EmailRequestPurpose(TextChoices):
 
 
 class EmailRequestSerializer(Serializer[Any], BaseMixin):
-    purpose = serializers.ChoiceField(choices=EmailRequestPurpose.choices)
+    purpose = serializers.ChoiceField(choices=EmailRequestPurpose.choices, default=EmailRequestPurpose.SIGNUP)
     email = BaseMixin.get_email_field()
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: EmailRequestSerializer의 `purpose` 필드에 디폴트 값을 추가했습니다.

## 📄 상세 내용
- [x] EmailRequestSerializer의 `purpose` 필드에 디폴트 값을 추가하여 사용하지 않을 경우에도 기본값이 적용되도록 수정.

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).