### PR TITLE
🐛 fix : content_preview 가 태그도 가져오는거 해결

### DIFF
--- a/apps/qna/serializers/question/question_list.py
+++ b/apps/qna/serializers/question/question_list.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from django.utils.html import strip_tags
 from rest_framework import serializers
 
 from apps.qna.models import Question
@@ -15,7 +16,7 @@ class QuestionListSerializer(serializers.ModelSerializer[Question]):
 
     author = AuthorSerializer(read_only=True)
 
-    content_preview = serializers.CharField()
+    content_preview = serializers.SerializerMethodField()
     answer_count = serializers.IntegerField()
 
     thumbnail_img_url = serializers.URLField(
@@ -50,3 +51,8 @@ class QuestionListSerializer(serializers.ModelSerializer[Question]):
             self._category_cache[category_id] = build_category_info(obj.category)
 
         return self._category_cache[category_id]
+
+    # obj.content_preview가 존재하면 태그를 제거하고 반환, 없으면 빈 문자열
+    def get_content_preview(self, obj: Question) -> str:
+        content = getattr(obj, "content_preview", "")
+        return strip_tags(content)

--- a/apps/qna/tests/question/api/test_list_api.py
+++ b/apps/qna/tests/question/api/test_list_api.py
@@ -80,3 +80,42 @@ class QuestionListAPITests(APITestCase):
         response = self.client.get(self.url, {"page": "abc"})
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    # content_preview에서 HTML 태그가 제거되었는지 확인하는 테스트
+    def test_question_list_content_preview_strips_tags(self) -> None:
+        # 1. 테스트 데이터 생성 (User, Category)
+        user = User.objects.create_user(
+            email="strip@test.com",
+            password="test1234",
+            name="태그제거테스트",
+            role=RoleChoices.ST,
+            phone_number="010-1111-2222",
+            gender="M",
+            birthday="2000-01-01",
+        )
+        category = QuestionCategory.objects.create(name="Frontend")
+
+        # 2. HTML 태그가 포함된 질문 생성
+        html_content = "<p>이것은 <b>굵은</b> 글씨이고, <br>줄바꿈도 있습니다.</p>"
+        Question.objects.create(
+            author=user,
+            category=category,
+            title="HTML 태그 포함 질문",
+            content=html_content,
+        )
+
+        # 3. API 호출
+        response = self.client.get(self.url)
+
+        # 4. 검증
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        item = response.data["results"][0]
+
+        # 태그가 제거된 순수 텍스트만 남아있는지 확인
+        expected_text = "이것은 굵은 글씨이고, 줄바꿈도 있습니다."
+
+        # strip_tags 결과에 따라 공백 처리가 조금 다를 수 있으므로 핵심 단어 포함 여부나 태그 부재 여부로 검증
+        self.assertNotIn("<p>", item["content_preview"])
+        self.assertNotIn("<b>", item["content_preview"])
+        self.assertNotIn("<br>", item["content_preview"])
+        self.assertIn("이것은 굵은 글씨이고", item["content_preview"])


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: 
- 작업 요약: content_preview 가 태그도 가져오는 문제 해결

## 📄 상세 내용
- [ ] 주요 변경 사항 1
- [ ] 주요 변경 사항 2
- [ ] 주요 변경 사항 3

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
